### PR TITLE
Add vendor accounts and pink theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-# AK
+# Womigoo
+
+Prototype skeleton for the Womigoo application, a platform inspired by Swiggy to empower women entrepreneurs selling local food products.
+
+## Structure
+
+- `backend/` – Node.js Express server with in-memory user and vendor accounts, kitchen listing and order APIs.
+- `frontend/` – React app powered by Vite with pages for user and vendor registration/login and browsing kitchens with a pink, Apple-inspired theme.
+
+## Getting Started
+
+### Backend
+
+```bash
+cd backend
+npm install
+npm start
+```
+
+### Frontend
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Both sides include a simple `npm test` placeholder command.
+
+### Sample API Usage
+
+- `POST /users/register` – create a user: `{ name, email, password }`
+- `POST /users/login` – authenticate user: `{ email, password }`
+- `POST /vendors/register` – register a vendor: `{ name, email, password }`
+- `POST /vendors/login` – authenticate vendor: `{ email, password }`
+- `GET /kitchens` – list available kitchens
+- `POST /orders` – place an order: `{ userId, kitchenId, items: [] }`

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,101 @@
+const express = require('express');
+const cors = require('cors');
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+// In-memory data stores
+const users = [];
+const vendors = [];
+const kitchens = [
+  {
+    id: 1,
+    name: 'Sample Kitchen',
+    menu: [
+      { id: 1, name: 'Rice Bowl', price: 120 },
+      { id: 2, name: 'Veg Curry', price: 80 }
+    ]
+  }
+];
+const orders = [];
+
+app.get('/', (req, res) => {
+  res.send('Womigoo backend running');
+});
+
+// Customer registration
+app.post('/users/register', (req, res) => {
+  const { name, email, password } = req.body;
+  if (!name || !email || !password) {
+    return res.status(400).json({ error: 'Missing fields' });
+  }
+  if (users.find(u => u.email === email)) {
+    return res.status(400).json({ error: 'User exists' });
+  }
+  const id = users.length + 1;
+  users.push({ id, name, email, password });
+  res.json({ id, name, email });
+});
+
+// Customer login
+app.post('/users/login', (req, res) => {
+  const { email, password } = req.body;
+  const user = users.find(u => u.email === email && u.password === password);
+  if (!user) {
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+  res.json({ id: user.id, name: user.name, email: user.email });
+});
+
+// Vendor registration
+app.post('/vendors/register', (req, res) => {
+  const { name, email, password } = req.body;
+  if (!name || !email || !password) {
+    return res.status(400).json({ error: 'Missing fields' });
+  }
+  if (vendors.find(v => v.email === email)) {
+    return res.status(400).json({ error: 'Vendor exists' });
+  }
+  const id = vendors.length + 1;
+  vendors.push({ id, name, email, password });
+  res.json({ id, name, email });
+});
+
+// Vendor login
+app.post('/vendors/login', (req, res) => {
+  const { email, password } = req.body;
+  const vendor = vendors.find(v => v.email === email && v.password === password);
+  if (!vendor) {
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+  res.json({ id: vendor.id, name: vendor.name, email: vendor.email });
+});
+
+app.get('/kitchens', (req, res) => {
+  res.json(kitchens);
+});
+
+app.post('/orders', (req, res) => {
+  const { userId, kitchenId, items } = req.body;
+  if (!userId || !kitchenId) {
+    return res.status(400).json({ error: 'Missing fields' });
+  }
+  const id = orders.length + 1;
+  orders.push({ id, userId, kitchenId, items: items || [], status: 'placed' });
+  res.json({ id });
+});
+
+app.get('/orders/:id', (req, res) => {
+  const order = orders.find(o => o.id === Number(req.params.id));
+  if (!order) {
+    return res.status(404).json({ error: 'Order not found' });
+  }
+  res.json(order);
+});
+
+app.listen(5000, () => {
+  console.log('Server running on http://localhost:5000');
+});
+
+module.exports = app;

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "womigoo-backend",
+  "version": "0.1.0",
+  "main": "index.js",
+  "type": "commonjs",
+  "scripts": {
+    "start": "node index.js",
+    "test": "echo \"No tests\" && exit 0"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.19.2"
+  }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Womigoo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "womigoo-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "test": "echo \"No tests\" && exit 0"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.3.9"
+  }
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,96 @@
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  background-color: #f5f5f7;
+  color: #1d1d1f;
+}
+
+nav {
+  display: flex;
+  gap: 1rem;
+  padding: 1rem 2rem;
+  background: #fff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  position: sticky;
+  top: 0;
+}
+
+nav a {
+  color: #ff2d55;
+  text-decoration: none;
+  font-weight: 500;
+  transition: color 0.2s ease;
+}
+
+nav a:hover {
+  color: #c9184a;
+}
+
+.container {
+  max-width: 480px;
+  margin: 2rem auto;
+  padding: 2rem;
+  background: #fff;
+  border-radius: 20px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+}
+
+input,
+button {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  border-radius: 12px;
+  border: 1px solid #d2d2d7;
+  font-size: 1rem;
+}
+
+input:focus {
+  outline: none;
+  border-color: #ff2d55;
+  box-shadow: 0 0 0 2px rgba(255, 45, 85, 0.3);
+}
+
+button {
+  background: #ff2d55;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+button:hover {
+  background: #c9184a;
+}
+
+ul {
+  list-style: none;
+  padding: 0;
+}
+
+li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid #e0e0e5;
+}
+
+li:last-child {
+  border-bottom: none;
+}
+
+.fade-in {
+  animation: fadeInUp 0.6s ease-out;
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
+import Home from './pages/Home';
+import Register from './pages/Register';
+import Login from './pages/Login';
+import Kitchens from './pages/Kitchens';
+import VendorRegister from './pages/VendorRegister';
+import VendorLogin from './pages/VendorLogin';
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <nav className="fade-in">
+        <Link to="/">Home</Link> |{' '}
+        <Link to="/register">User Register</Link> |{' '}
+        <Link to="/login">User Login</Link> |{' '}
+        <Link to="/vendor/register">Vendor Register</Link> |{' '}
+        <Link to="/vendor/login">Vendor Login</Link> |{' '}
+        <Link to="/kitchens">Kitchens</Link>
+      </nav>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/register" element={<Register />} />
+        <Route path="/login" element={<Login />} />
+        <Route path="/vendor/register" element={<VendorRegister />} />
+        <Route path="/vendor/login" element={<VendorLogin />} />
+        <Route path="/kitchens" element={<Kitchens />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './App.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function Home() {
+  return (
+    <div className="container fade-in">
+      <h1>Welcome to Womigoo</h1>
+      <p>Support women-led kitchens in your community.</p>
+    </div>
+  );
+}

--- a/frontend/src/pages/Kitchens.jsx
+++ b/frontend/src/pages/Kitchens.jsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+
+export default function Kitchens() {
+  const [kitchens, setKitchens] = useState([]);
+
+  useEffect(() => {
+    fetch('http://localhost:5000/kitchens')
+      .then((res) => res.json())
+      .then(setKitchens);
+  }, []);
+
+  const placeOrder = (kitchenId) => {
+    fetch('http://localhost:5000/orders', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: 1, kitchenId, items: [] }),
+    })
+      .then((res) => res.json())
+      .then((data) => alert(`Order ${data.id} placed`));
+  };
+
+  return (
+    <div className="container fade-in">
+      <h2>Kitchens</h2>
+      <ul>
+        {kitchens.map((k) => (
+          <li key={k.id}>
+            {k.name}
+            <button onClick={() => placeOrder(k.id)}>Order</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+
+export default function Login() {
+  const [form, setForm] = useState({ email: '', password: '' });
+  const [message, setMessage] = useState('');
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    fetch('http://localhost:5000/users/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    })
+      .then((res) => res.json())
+      .then((data) => setMessage(data.error ? data.error : `Welcome ${data.name}`));
+  };
+
+  return (
+    <form className="container fade-in" onSubmit={handleSubmit}>
+      <h2>Login</h2>
+      <input
+        name="email"
+        value={form.email}
+        onChange={handleChange}
+        placeholder="Email"
+      />
+      <input
+        name="password"
+        type="password"
+        value={form.password}
+        onChange={handleChange}
+        placeholder="Password"
+      />
+      <button type="submit">Sign in</button>
+      {message && <p>{message}</p>}
+    </form>
+  );
+}

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+
+export default function Register() {
+  const [form, setForm] = useState({ name: '', email: '', password: '' });
+  const [message, setMessage] = useState('');
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    fetch('http://localhost:5000/users/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    })
+      .then((res) => res.json())
+      .then((data) => setMessage(data.error || 'Registered!'));
+  };
+
+  return (
+    <form className="container fade-in" onSubmit={handleSubmit}>
+      <h2>Register</h2>
+      <input
+        name="name"
+        value={form.name}
+        onChange={handleChange}
+        placeholder="Name"
+      />
+      <input
+        name="email"
+        value={form.email}
+        onChange={handleChange}
+        placeholder="Email"
+      />
+      <input
+        name="password"
+        type="password"
+        value={form.password}
+        onChange={handleChange}
+        placeholder="Password"
+      />
+      <button type="submit">Sign up</button>
+      {message && <p>{message}</p>}
+    </form>
+  );
+}

--- a/frontend/src/pages/VendorLogin.jsx
+++ b/frontend/src/pages/VendorLogin.jsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+
+export default function VendorLogin() {
+  const [form, setForm] = useState({ email: '', password: '' });
+  const [message, setMessage] = useState('');
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    fetch('http://localhost:5000/vendors/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    })
+      .then((res) => res.json())
+      .then((data) => setMessage(data.error ? data.error : `Welcome ${data.name}`));
+  };
+
+  return (
+    <form className="container fade-in" onSubmit={handleSubmit}>
+      <h2>Vendor Login</h2>
+      <input
+        name="email"
+        value={form.email}
+        onChange={handleChange}
+        placeholder="Email"
+      />
+      <input
+        name="password"
+        type="password"
+        value={form.password}
+        onChange={handleChange}
+        placeholder="Password"
+      />
+      <button type="submit">Sign in</button>
+      {message && <p>{message}</p>}
+    </form>
+  );
+}

--- a/frontend/src/pages/VendorRegister.jsx
+++ b/frontend/src/pages/VendorRegister.jsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+
+export default function VendorRegister() {
+  const [form, setForm] = useState({ name: '', email: '', password: '' });
+  const [message, setMessage] = useState('');
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    fetch('http://localhost:5000/vendors/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    })
+      .then((res) => res.json())
+      .then((data) => setMessage(data.error || 'Vendor registered!'));
+  };
+
+  return (
+    <form className="container fade-in" onSubmit={handleSubmit}>
+      <h2>Vendor Register</h2>
+      <input
+        name="name"
+        value={form.name}
+        onChange={handleChange}
+        placeholder="Name"
+      />
+      <input
+        name="email"
+        value={form.email}
+        onChange={handleChange}
+        placeholder="Email"
+      />
+      <input
+        name="password"
+        type="password"
+        value={form.password}
+        onChange={handleChange}
+        placeholder="Password"
+      />
+      <button type="submit">Sign up</button>
+      {message && <p>{message}</p>}
+    </form>
+  );
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000
+  }
+});


### PR DESCRIPTION
## Summary
- separate user and vendor authentication endpoints
- add vendor login/register pages with pink Apple-inspired styling
- apply pink accent theme and input focus animation across UI

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_689f7346259c832abd78275387655c4e