### PR TITLE
Add kitchen card grid component and styles

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,48 @@
+.kitchen-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.kitchen-card {
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.kitchen-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+.kitchen-card img {
+  width: 100%;
+  height: 160px;
+  object-fit: cover;
+}
+
+.kitchen-details {
+  padding: 0.5rem 1rem 1rem;
+}
+
+.rating {
+  font-weight: bold;
+  margin-top: 0.25rem;
+}
+
+.cuisines {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.cuisines span {
+  background: #f0f0f0;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+}

--- a/frontend/src/pages/Kitchens.jsx
+++ b/frontend/src/pages/Kitchens.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import '../App.css';
+
+const kitchens = [
+  {
+    id: 1,
+    name: 'Italian Bistro',
+    image: 'https://via.placeholder.com/400x300?text=Italian+Bistro',
+    rating: 4.2,
+    cuisines: ['Italian', 'Pizza']
+  },
+  {
+    id: 2,
+    name: 'Sushi House',
+    image: 'https://via.placeholder.com/400x300?text=Sushi+House',
+    rating: 4.8,
+    cuisines: ['Japanese', 'Sushi']
+  },
+  {
+    id: 3,
+    name: 'Spicy Thai',
+    image: 'https://via.placeholder.com/400x300?text=Spicy+Thai',
+    rating: 4.5,
+    cuisines: ['Thai', 'Spicy']
+  }
+];
+
+export default function Kitchens() {
+  return (
+    <div className="kitchen-grid">
+      {kitchens.map((kitchen) => (
+        <div key={kitchen.id} className="kitchen-card">
+          <img src={kitchen.image} alt={kitchen.name} />
+          <div className="kitchen-details">
+            <h3>{kitchen.name}</h3>
+            <div className="rating">⭐ {kitchen.rating.toFixed(1)}</div>
+            <div className="cuisines">
+              {kitchen.cuisines.map((cuisine) => (
+                <span key={cuisine}>{cuisine}</span>
+              ))}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement Kitchens page displaying kitchens as responsive cards with images, ratings, and cuisine tags
- add card grid styles for responsive layout and hover effect

## Testing
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68a01a510ab0832a974670b4afc247a3